### PR TITLE
Send auth token to secure Zapier webhooks

### DIFF
--- a/functions/tutorPortalRequests.js
+++ b/functions/tutorPortalRequests.js
@@ -17,6 +17,8 @@ const twilioClient = new twilio(twilioAccountSid, twilioAuthToken)
 const zoomAPIKey = functions.config().zoom.api_key
 const zoomAPISecret = functions.config().zoom.api_secret
 
+const zapierAuthToken = functions.config().zapier.auth_token
+
 //Step Up custom credentials
 const stepUpTokenEncryptionKey = functions.config().stepup.token_encryption_key
 
@@ -465,6 +467,7 @@ exports.onNewUserCreated = functions.auth.user().onCreate((user) => {
             method: 'post',
             body: JSON.stringify({
                 email: email,
+                authToken: zapierAuthToken,
                 signInLink: emailSignInLink
             })
         })
@@ -510,6 +513,7 @@ exports.sendEmailSignInLink = functions.https.onCall(async (data, context) => {
                 method: 'post',
                 body: JSON.stringify({
                     email: email,
+                    authToken: zapierAuthToken,
                     signInLink: emailSignInLink
                 })
             })


### PR DESCRIPTION
A couple of the zapier webhooks could be called by anyone as of right now, so I added an auth token to the requests so we can authenticate the requests on Zapier's end.