### PR TITLE
Fix support page icon size on safari

### DIFF
--- a/public/src/index.css
+++ b/public/src/index.css
@@ -495,7 +495,7 @@ a.cancel-and-reschedule-links:hover {
 }
 
 .support-item-icon {
-    font-size: xxx-large;
+    font-size: 28pt;
     color: #1BCBD9;
 }
 


### PR DESCRIPTION
Closes https://github.com/StepUp-Tutoring/firebase-code/issues/72

**What**
Manually specify the icon sizes for the support page rather then using the `xxx-large` size.

**Why**
The `xxx-large` size constant is not supported on Safari. See https://caniuse.com/?search=xxx-large

| Before | After |
| --- | --- |
| <img width="1215" alt="Screen Shot 2021-10-03 at 6 24 17 PM" src="https://user-images.githubusercontent.com/8084674/135780932-3eaaf518-972c-4a38-9a72-d0e548cb9425.png"> | <img width="1216" alt="Screen Shot 2021-10-03 at 6 23 16 PM" src="https://user-images.githubusercontent.com/8084674/135780892-4cdb0748-cdf6-4c33-b20d-81c5d9177aca.png">
 
