### PR TITLE
Add responsive layout for support and onboarding dashboard pages

### DIFF
--- a/public/src/index.css
+++ b/public/src/index.css
@@ -680,3 +680,37 @@ div.info-bar {
     align-items: center;
     justify-content: center;
 }
+
+@media only screen and (max-width: 768px) {
+    /* --- Dashboard Page ---- */
+    .content-container {
+        margin: 0;
+        border-radius: 0;
+        padding-top: 16pt;
+        /* prevents the view from squishing beyond a reasonable size when the sidebar is visible */
+        min-width: 300px;
+    }
+
+    .main-content {
+        margin: 0;
+    }
+
+    .dashboard-required-items {
+        flex-direction: column;
+    }
+
+    /* --- Support Page ---- */
+    .support-container {
+        padding: 0;
+    }
+
+    .support-content-container {
+        margin: 0;
+        /* prevents the view from squishing beyond a reasonable size when the sidebar is visible */
+        min-width: 300px;
+    }
+    .support-item-inner-div {
+        /* allows for text to overflow (this is disabled by default in ant)*/
+        white-space: normal;
+    }
+}

--- a/public/src/sidebarLayout.js
+++ b/public/src/sidebarLayout.js
@@ -195,7 +195,7 @@ class SidebarLayout extends React.Component {
 
         return <Layout style={{ height: '100%' }} className='desktop-dashboard'>
 
-            <Sider theme='light' className='dashboard-sidebar' breakpoint='sm' width='240'>
+            <Sider theme='light' className='dashboard-sidebar' breakpoint='sm' collapsedWidth="0" width='240' zeroWidthTriggerStyle={{ top: 0 }}>
                 <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
 
                     <div className='sidebar-header hoverable' onClick={() => this.onSideBarItemClicked('home')} >
@@ -275,16 +275,6 @@ class SidebarLayout extends React.Component {
                         </div>
                     </Content>
                 </Layout>
-
-                { window.matchMedia('screen and (max-width: 500px)').matches && <Footer style={{backgroundColor: 'white'}}>
-
-                    <Tabs>
-                        <TabPane tab='Dashboard'>
-
-                        </TabPane>
-                    </Tabs>
-
-                </Footer>}
 
             </Layout>
 


### PR DESCRIPTION
**What**
Added responsive layouts to allow the page to properly reflow on mobile devices.

| Dashboard | Expanded Side bar | Support Page |
| --- | --- | --- |
| ![localhost_5000_onboarding_dashboard html](https://user-images.githubusercontent.com/8084674/135783854-8bcb27a7-9c29-4346-afca-8dcde7036840.png) | ![localhost_5000_onboarding_dashboard html (1)](https://user-images.githubusercontent.com/8084674/135783908-c56297a3-8b0d-4fdd-b0bc-0652a9989da8.png) | ![localhost_5000_onboarding_dashboard html (3)](https://user-images.githubusercontent.com/8084674/135783974-5b1aeea4-21a6-4d8a-aeff-7fad29230177.png) |
 